### PR TITLE
improvement: add real-time stdout streaming for remote execution

### DIFF
--- a/examples/simple_streaming.py
+++ b/examples/simple_streaming.py
@@ -1,0 +1,26 @@
+from pyremote import remote, UvConfig
+
+@remote(
+    "localhost", 
+    "ubuntu", 
+    password="ubuntu123",
+    uv=UvConfig(path="~/.venv", python_version="3.12"),
+    timeout=60
+)
+def streaming_loop():
+    import time
+    import sys
+    
+    print(f"Python version: {sys.version}")
+    print("Starting loop...")
+    
+    for i in range(5):
+        print(f"Processing item {i+1}/5")
+        time.sleep(1)
+    
+    print("Done!")
+    return {"status": "completed", "items": 5}
+
+if __name__ == "__main__":
+    result = streaming_loop()
+    print(f"Result: {result}")


### PR DESCRIPTION
### **[Changes]**
1. Read from SSH channel incrementally using channel.recv() instead of stdout.read()
2. Print each line immediately with flush=True as it's received
3. Remove duplicate print in execute() since output is now streamed in real-time
> Before: All output appears at once after function completes
> After: Output appears line-by-line as the remote function runs