### PR TITLE
improvement: add stdout_callback for real-time output capture

### DIFF
--- a/examples/simple_stdout_callback.py
+++ b/examples/simple_stdout_callback.py
@@ -1,0 +1,43 @@
+from pyremote import remote, UvConfig
+
+# Collect logs in real-time using a callback
+logs = []
+
+def log_handler(line: str):
+    """Callback that receives each line of stdout as it streams."""
+    logs.append(line)
+    # You could also send to logging, websocket, database, etc.
+    # Example: logger.info(line)
+    # Example: websocket.send(line)
+
+@remote(
+    "localhost", 
+    "ubuntu", 
+    password="ubuntu123",
+    uv=UvConfig(path="~/.venv", python_version="3.12"),
+    timeout=60,
+    stdout_callback=log_handler,
+)
+def task_with_logging():
+    import time
+    import sys
+    
+    print(f"Python version: {sys.version}")
+    print("Starting task...")
+    
+    for i in range(5):
+        print(f"Processing step {i+1}/5")
+        time.sleep(1)
+    
+    print("Task completed!")
+    return {"status": "completed", "steps": 5}
+
+if __name__ == "__main__":
+    result = task_with_logging()
+    
+    print("\n--- Captured Logs ---")
+    for log in logs:
+        print(f"  > {log}")
+    
+    print(f"\nResult: {result}")
+    print(f"Total log lines captured: {len(logs)}")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pyremote",
-    version="0.1",
+    version="0.1.1",
     author="husein",
     url="https://github.com/Scicom-AI-Enterprise-Organization/pyremote",
     packages=find_packages(),


### PR DESCRIPTION
## Changes
- add `stdout_callback` parameter to `remote()` decorator and `RemoteExecutor` class
- callback function receives each line of stdout as it streams from remote execution
- useful for benchmarq a.k.a benchmaxxing a.k.a benchmark tool to capture log and store into .txt and .json
- bumped version to 0.1.1

> **Before:** output is printed to stdout but cannot be programmatically captured in real-time
> **After:** optional callback receives each line as it streams, enabling custom handling


## Test

1. running example code under folder examples
```bash
python3 examples/simple_stdout_callback.py
```

> <img width="1846" height="648" alt="image" src="https://github.com/user-attachments/assets/1626403c-d990-4272-a511-8c7d0e42eb62" />
> Logs has been captured and can be used by anyone for logging.
